### PR TITLE
Specify installation location for survcomp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     nlme,
     purrr,
     stats,
-    survcomp (>= 3.17),
+    survcomp (>= 1.50.0),
     survival,
     survivalROC
 Suggests: knitr, ptmixed, rmarkdown, survminer

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Depends: R (>= 4.1.0)
 VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 7.2.2
+biocViews:
 Imports: doParallel, dplyr, foreach, glmnet, lcmm, magic, MASS, Matrix,
         methods, nlme, purrr, stats, survcomp, survival, survivalROC
 Suggests: knitr, ptmixed, rmarkdown, survminer

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,22 @@ VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 7.2.2
 biocViews:
-Imports: doParallel, dplyr, foreach, glmnet, lcmm, magic, MASS, Matrix,
-        methods, nlme, purrr, stats, survcomp, survival, survivalROC
+Imports: 
+    doParallel,
+    dplyr,
+    foreach,
+    glmnet,
+    lcmm,
+    magic,
+    MASS,
+    Matrix,
+    methods,
+    nlme,
+    purrr,
+    stats,
+    survcomp (>= 3.17),
+    survival,
+    survivalROC
 Suggests: knitr, ptmixed, rmarkdown, survminer
 NeedsCompilation: no
 Packaged: 2022-12-15 11:49:40 UTC; ms


### PR DESCRIPTION
Adding `biocViews:` to the DESCRIPTION file seems to be an [undescribed hack](https://github.com/r-lib/devtools/issues/700#issuecomment-235127291) to allow installation of dependencies from bioconductor. I have also specified the latest version for `survcomp`, since this one does not exist on CRAN.

After uninstalling `pencal` and `survcomp` (and `survival`) from my system, I re-installed from my fork:

```
devtools::install_gitub("bvreede/pencal_devel")
```

which installed without issues, with the following console information, showing that indeed `survcomp` is installed from Bioconductor:

```
> devtools::install_github("bvreede/pencal_devel")
Downloading GitHub repo bvreede/pencal_devel@HEAD
Installing 2 packages: survival, survcomp
trying URL 'https://cran.rstudio.com/bin/macosx/big-sur-x86_64/contrib/4.3/survival_3.5-5.tgz'
Content type 'application/x-gzip' length 6850717 bytes (6.5 MB)
==================================================
downloaded 6.5 MB

trying URL 'https://bioconductor.org/packages/3.17/bioc/bin/macosx/big-sur-x86_64/contrib/4.3/survcomp_1.50.0.tgz'
Content type 'application/x-gzip' length 851649 bytes (831 KB)
==================================================
downloaded 831 KB
```

Closes #3 